### PR TITLE
Dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 license = "CECILL-2.1"
 
 dependencies = [
-    "esgvoc>=4.0.0",
+    "esgvoc>=4.2.0",
     "fastapi>=0.115.8,<0.118.0",
     "gunicorn>=23.0.0",
     "httptools>=0.6.4",

--- a/src/esgvoc_backend/__init__.py
+++ b/src/esgvoc_backend/__init__.py
@@ -3,7 +3,7 @@ import logging.config
 
 from esgvoc_backend import constants
 
-__version__ = "4.1.0"
+__version__ = "4.2.0"
 
 logging_config = {
     'version': 1,

--- a/src/esgvoc_backend/projects.py
+++ b/src/esgvoc_backend/projects.py
@@ -122,3 +122,20 @@ async def get_term_in_collection(
         project_id=project_id, collection_id=collection_id, term_id=term_id, selected_term_fields=selected_term_fields
     )
     return check_result(result)
+
+
+@router.get(
+    "/{project_id}/collections/{collection_id}/model",
+    summary="Get the Pydantic model JSON schema of a given collection",
+    description=generate_route_desc(f"{PROJECTS_PAGE_PREFIX}.get_model_from_collection"),
+)
+async def get_model_from_collection(
+    project_id: Annotated[str, Path(description="an id of a project")],
+    collection_id: Annotated[str, Path(description="an id of a collection")],
+    version: Annotated[str | None, Query(description="a project version")] = None,
+) -> dict:
+    model = projects.get_model_from_collection(
+        project_id=project_id, collection_id=collection_id, version=version
+    )
+    result = check_result(model)
+    return result.model_json_schema()

--- a/src/esgvoc_backend/universe.py
+++ b/src/esgvoc_backend/universe.py
@@ -3,7 +3,7 @@ from typing import Annotated
 import esgvoc.api.universe as universe
 from esgvoc.api.data_descriptors.data_descriptor import DataDescriptor
 from fastapi import APIRouter, Path, Query
-from pydantic import SerializeAsAny
+from pydantic import SerializeAsAny, TypeAdapter
 
 from esgvoc_backend.cache import SUGGESTED_TERMS_OF_UNIVERSE, SuggestedTerm
 from esgvoc_backend.constants import UNIVERSE_PAGE_PREFIX
@@ -77,6 +77,18 @@ async def get_term_in_data_descriptor(
                                                   term_id=term_id,
                                                   selected_term_fields=selected_term_fields)
     return check_result(result)
+
+
+@router.get("/data_descriptors/{data_descriptor_id}/model",
+            summary="Get the Pydantic model JSON schema of a given data descriptor",
+            description=generate_route_desc(f'{UNIVERSE_PAGE_PREFIX}.get_model_from_data_descriptor'))
+async def get_model_from_data_descriptor(
+    data_descriptor_id: Annotated[str, Path(description="an id of a data descriptor")]) -> dict:
+    model = universe.get_model_from_data_descriptor(data_descriptor_id=data_descriptor_id)
+    result = check_result(model)
+    if hasattr(result, 'model_json_schema'):
+        return result.model_json_schema()
+    return TypeAdapter(result).json_schema()
 
 
 @router.get("/suggested/terms", summary="Get the suggested terms of the universe per data descriptors")

--- a/tests/test_projects_api.py
+++ b/tests/test_projects_api.py
@@ -1,4 +1,5 @@
 import pytest
+from fastapi import HTTPException
 
 from esgvoc_backend import projects
 from tests.api_inputs import get_param  # noqa: F401
@@ -174,6 +175,30 @@ def test_get_term_in_collection(client, get_param) -> None:
     # 'nothing' should not be included (invalid field)
     assert "nothing" not in json_result
     # 'type' and 'description' are NOT included when selected_term_fields is used
+
+
+def test_get_model_from_collection(client, get_param) -> None:
+    """Test GET /projects/{project_id}/collections/{collection_id}/model returns JSON schema."""
+    url = f"/{get_param.project_id}/collections/{get_param.collection_id}/model"
+
+    response = client.get(url=url)
+    assert response.status_code == 200
+
+    json_result = response.json()
+    assert isinstance(json_result, dict)
+    assert "title" in json_result
+    assert "properties" in json_result
+    assert "type" in json_result
+    assert json_result["type"] == "object"
+
+
+def test_get_model_from_collection_not_found(client) -> None:
+    """Test GET /projects/{project_id}/collections/{collection_id}/model raises 404 for unknown ids."""
+    url = "/nonexistent/collections/nonexistent/model"
+
+    with pytest.raises(HTTPException) as exc_info:
+        client.get(url=url)
+    assert exc_info.value.status_code == 404
 
 
 def test_get_collection_in_project(client, get_param) -> None:

--- a/tests/test_universe_api.py
+++ b/tests/test_universe_api.py
@@ -1,4 +1,5 @@
 import pytest
+from fastapi import HTTPException
 
 from esgvoc_backend import universe
 from tests.api_inputs import get_param  # noqa: F401
@@ -166,6 +167,35 @@ def test_get_term_in_data_descriptor(client, get_param) -> None:
     assert 'nothing' not in json_result
     # 'type' and 'description' are NOT included when selected_term_fields is used
     # 'drs_name' may or may not be present depending on term type
+
+
+def test_get_model_from_data_descriptor(client, get_param) -> None:
+    """Test GET /universe/data_descriptors/{data_descriptor_id}/model returns JSON schema."""
+    url = f'/data_descriptors/{get_param.data_descriptor_id}/model'
+
+    response = client.get(url=url)
+    assert response.status_code == 200
+
+    json_result = response.json()
+    assert isinstance(json_result, dict)
+    # Single model: has title/properties/type at top level
+    # Union model: has $defs and oneOf/anyOf at top level
+    is_single_model = 'title' in json_result
+    if is_single_model:
+        assert 'properties' in json_result
+        assert json_result['type'] == 'object'
+    else:
+        assert '$defs' in json_result
+        assert 'oneOf' in json_result or 'anyOf' in json_result
+
+
+def test_get_model_from_data_descriptor_not_found(client) -> None:
+    """Test GET /universe/data_descriptors/{data_descriptor_id}/model raises 404 for unknown id."""
+    url = '/data_descriptors/nonexistent/model'
+
+    with pytest.raises(HTTPException) as exc_info:
+        client.get(url=url)
+    assert exc_info.value.status_code == 404
 
 
 def test_get_suggested_terms_in_universe(client) -> None:


### PR DESCRIPTION
 Added
  - New route `GET /api/v1/universe/data_descriptors/{id}/model` to retrieve
    the Pydantic model JSON schema of a data descriptor (supports union types)
  - New route `GET /api/v1/projects/{project_id}/collections/{collection_id}/model`
    to retrieve the Pydantic model JSON schema of a collection (with optional version param)
  - Tests for both new routes (including not-found cases)